### PR TITLE
feat: add org api with `getOrg(opts)` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > Node.js SDK for the SalesVista REST API
 
+[![Build Status](https://travis-ci.com/SalesVista/api-client-node.svg?branch=master)](https://travis-ci.com/SalesVista/api-client-node)
+[![Coverage Status](https://coveralls.io/repos/github/SalesVista/api-client-node/badge.svg?branch=master)](https://coveralls.io/github/SalesVista/api-client-node?branch=master)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 

--- a/api/org.js
+++ b/api/org.js
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 SalesVista, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const Api = require('./api')
+
+class OrgApi extends Api {
+  static get (opts) {
+    return new OrgApi(opts)
+  }
+
+  async getOrg (opts) {
+    opts = opts || {}
+    const orgId = opts.id || await this.client.getOrgId()
+    let route = `/orgs/${orgId}`
+
+    // params: withCounts (boolean), from (date), to (date), fiscalYearId (string), fiscalPeriodId (string)
+    if (opts.withCounts === true) {
+      route += '?withCounts=true'
+      if (opts.from && opts.to) route += `&from=${opts.from}&to=${opts.to}`
+      if (opts.fiscalYearId) route += `&fiscalYearId=${opts.fiscalYearId}`
+      if (opts.fiscalPeriodId) route += `&fiscalPeriodId=${opts.fiscalPeriodId}`
+    }
+
+    const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+}
+
+module.exports = OrgApi

--- a/api/product-categories.js
+++ b/api/product-categories.js
@@ -27,7 +27,7 @@ class ProductCategoriesApi extends Api {
     } = opts
 
     const orgId = opts.orgId || await this.client.getOrgId()
-    let route = `/orgs/${orgId}/product-categories?page=${page}&size=${size}`
+    const route = `/orgs/${orgId}/product-categories?page=${page}&size=${size}`
     const r = await this.client.get(route, opts) // TODO wrap this.client.get that throws on 4xx/5xx response
     return r && r.body
   }

--- a/api/reps.js
+++ b/api/reps.js
@@ -27,7 +27,7 @@ class RepsApi extends Api {
     } = opts
 
     const orgId = opts.orgId || await this.client.getOrgId()
-    let route = `/orgs/${orgId}/searchable-reps?page=${page}&size=${size}`
+    const route = `/orgs/${orgId}/searchable-reps?page=${page}&size=${size}`
     // TODO all other query params
     const r = await this.client.get(route, opts) // TODO wrap this.client.get that throws on 4xx/5xx response
     return r && r.body

--- a/api/sales.js
+++ b/api/sales.js
@@ -36,7 +36,8 @@ class SalesApi extends Api {
   }
 
   async createBatch (opts) {
-    const { name,
+    const {
+      name,
       externalOrg,
       sales // verify it is an array?
     } = opts
@@ -50,7 +51,7 @@ class SalesApi extends Api {
 
     if (sales) request.sales = sales
 
-    let route = `/orgs/${orgId}/sale-external-batches`
+    const route = `/orgs/${orgId}/sale-external-batches`
     const r = await this.client.post(route, request, opts) // TODO wrap this.client.post that throws on 4xx/5xx response
     return r && r.body
   }
@@ -68,7 +69,7 @@ class SalesApi extends Api {
 
     if (sales) request.sales = sales
 
-    let route = `/sale-batches/${batchId}`
+    const route = `/sale-batches/${batchId}`
     const r = await this.client.put(route, request, opts) // TODO wrap this.client.put that throws on 4xx/5xx response
     return r && r.body
   }

--- a/client.js
+++ b/client.js
@@ -68,9 +68,10 @@ class SVClient {
     this._cacheStrategy = opts.cacheStrategy || this._cacheStrategy
 
     // api modules
+    this._org = opts.org || this._org
+    this._productCategories = opts.productCategories || this._productCategories
     this._reps = opts.reps || this._reps
     this._sales = opts.sales || this._sales
-    this._productCategories = opts.productCategories || this._productCategories
 
     return this
   }
@@ -252,6 +253,16 @@ class SVClient {
     return this.orgId
   }
 
+  get org () {
+    if (!this._org) this._org = require('./api/org').get({ client: this })
+    return this._org
+  }
+
+  get productCategories () {
+    if (!this._productCategories) this._productCategories = require('./api/product-categories').get({ client: this })
+    return this._productCategories
+  }
+
   get reps () {
     if (!this._reps) this._reps = require('./api/reps').get({ client: this })
     return this._reps
@@ -260,11 +271,6 @@ class SVClient {
   get sales () {
     if (!this._sales) this._sales = require('./api/sales').get({ client: this })
     return this._sales
-  }
-
-  get productCategories () {
-    if (!this._productCategories) this._productCategories = require('./api/product-categories').get({ client: this })
-    return this._productCategories
   }
 
   // this method will throw an error for any of the following 4 scenarios:

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "got": "^9.6.0"
   },
   "devDependencies": {
-    "ava": "^2.1.0",
+    "ava": "^2.3.0",
     "c8": "^5.0.1",
-    "coveralls": "^3.0.4",
+    "coveralls": "^3.0.6",
     "standard": "^12.0.1",
     "standard-version": "^6.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ava": "^2.3.0",
     "c8": "^5.0.1",
     "coveralls": "^3.0.6",
-    "standard": "^12.0.1",
+    "standard": "^14.0.0",
     "standard-version": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "c8": "^5.0.1",
     "coveralls": "^3.0.6",
     "standard": "^12.0.1",
-    "standard-version": "^6.0.1"
+    "standard-version": "^7.0.0"
   }
 }


### PR DESCRIPTION
I plan on using this to fetch the org slug on connector startup for logging/auditing/troubleshooting purposes.

Went ahead and updated dependencies while I'm at it.