### PR TITLE
feat: list products, put org external key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ language: node_js
 node_js:
   - 'node'
   - 'lts/*'
+  - '10'
 after_success: npm run coverage

--- a/api/org.js
+++ b/api/org.js
@@ -22,7 +22,7 @@ class OrgApi extends Api {
 
   async getOrg (opts) {
     opts = opts || {}
-    const orgId = opts.id || await this.client.getOrgId()
+    const orgId = opts.id || opts.orgId || await this.client.getOrgId()
     let route = `/orgs/${orgId}`
 
     // params: withCounts (boolean), from (date), to (date), fiscalYearId (string), fiscalPeriodId (string)
@@ -34,6 +34,18 @@ class OrgApi extends Api {
     }
 
     const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+
+  async putExternalOrgKey (system, key, opts) {
+    opts = opts || {}
+    const orgId = opts.id || opts.orgId || await this.client.getOrgId()
+    const route = `/orgs/${orgId}/external-orgs/${system}/${key}`
+
+    const body = {}
+    if (opts.name || opts.companyName) body.name = opts.name || opts.companyName
+
+    const r = await this.client.put(route, body, opts)
     return r && r.body
   }
 }

--- a/api/products.js
+++ b/api/products.js
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 SalesVista, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const Api = require('./api')
+
+class ProductsApi extends Api {
+  static get (opts) {
+    return new ProductsApi(opts)
+  }
+
+  async getProducts (opts = {}) {
+    const {
+      page = 1,
+      size = 50
+    } = opts
+
+    // TODO params: name (1+ strings), inAnyPcat (boolean)
+
+    const orgId = opts.orgId || await this.client.getOrgId()
+    const route = `/orgs/${orgId}/products?page=${page}&size=${size}`
+    const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+}
+
+module.exports = ProductsApi

--- a/client.js
+++ b/client.js
@@ -70,6 +70,7 @@ class SVClient {
     // api modules
     this._org = opts.org || this._org
     this._productCategories = opts.productCategories || this._productCategories
+    this._products = opts.products || this._products
     this._reps = opts.reps || this._reps
     this._sales = opts.sales || this._sales
 
@@ -261,6 +262,11 @@ class SVClient {
   get productCategories () {
     if (!this._productCategories) this._productCategories = require('./api/product-categories').get({ client: this })
     return this._productCategories
+  }
+
+  get products () {
+    if (!this._products) this._products = require('./api/products').get({ client: this })
+    return this._products
   }
 
   get reps () {


### PR DESCRIPTION
Adds the following:

- `products` api, with a single `getProducts(opts)` method, for listing products
- `putExternalOrgKey(system, key, opts)` method to the existing `org` api, for upserting an external key (system and key combo) for an org

Both of these are used in official connector integrations.