### PR TITLE
chore: bump dependencies, Oct 2019 edition

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "got": "^9.6.0"
   },
   "devDependencies": {
-    "ava": "^2.3.0",
+    "ava": "^2.4.0",
     "c8": "^5.0.4",
     "coveralls": "^3.0.7",
     "standard": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ava": "^2.4.0",
     "c8": "^5.0.4",
     "coveralls": "^3.0.7",
-    "standard": "^14.0.0",
+    "standard": "^14.3.1",
     "standard-version": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "devDependencies": {
     "ava": "^2.3.0",
-    "c8": "^5.0.1",
-    "coveralls": "^3.0.6",
+    "c8": "^5.0.4",
+    "coveralls": "^3.0.7",
     "standard": "^14.0.0",
     "standard-version": "^7.0.0"
   }


### PR DESCRIPTION
Bumps the following:

- `ava` from 2.3.0 to 2.4.0 (minor)
- `c8` from 5.0.1 to 5.0.4 (patch)
- `coveralls` from 3.0.6 to 3.0.7 (patch)
- `standard` from 14.0.0 to 14.3.1 (minor)