### PR TITLE
chore: upgrade dependencies, August 2021 edition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 16
           - 14
           - 12
     steps:

--- a/client.js
+++ b/client.js
@@ -162,7 +162,7 @@ class SVClient {
 
     const gotOpts = {
       method: opts.method || 'GET',
-      json: true, // accept: application/json
+      responseType: 'json', // accept: application/json
       headers: {
         'User-Agent': this.userAgent,
         ...this.defaultHeaders,
@@ -171,8 +171,10 @@ class SVClient {
     }
 
     if (data && ['POST', 'PUT', 'DELETE', 'PATCH'].includes(String(gotOpts.method).toUpperCase())) {
-      gotOpts.body = data
-      if (opts.oauth) gotOpts.form = true // content-type: application/x-www-form-urlencoded
+      // form = content-type: application/x-www-form-urlencoded
+      // json = content-type: application/json
+      const bodyPropName = opts.oauth ? 'form' : 'json'
+      gotOpts[bodyPropName] = data
     }
 
     if (opts.oauth) {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   "devDependencies": {
     "ava": "^2.4.0",
     "c8": "^5.0.4",
-    "coveralls": "^3.0.7",
+    "coveralls": "^3.1.1",
     "standard": "^16.0.3",
-    "standard-version": "^7.0.0"
+    "standard-version": "^9.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/SalesVista/api-client-node#readme",
   "dependencies": {
-    "got": "^9.6.0"
+    "got": "^11.8.2"
   },
   "devDependencies": {
     "ava": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ava": "^2.4.0",
     "c8": "^5.0.4",
     "coveralls": "^3.0.7",
-    "standard": "^14.3.1",
+    "standard": "^16.0.3",
     "standard-version": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "got": "^11.8.2"
   },
   "devDependencies": {
-    "ava": "^2.4.0",
-    "c8": "^5.0.4",
+    "ava": "^3.15.0",
+    "c8": "^7.8.0",
     "coveralls": "^3.1.1",
     "standard": "^16.0.3",
     "standard-version": "^9.3.1"


### PR DESCRIPTION
Bumps the following dependencies:

- Runtime/Production
  - `got` 9.6.0 ➡️ 11.82
- Development
  - `ava` 2.4.0 ➡️ 3.15.0
  - `c8` 5.0.4 ➡️ 7.8.0
  - `coveralls`  3.0.7 ➡️ 3.1.1
  - `standard` 14.3.1 ➡️ 16.0.3
  - `standard-version` 7.0.0 ➡️ 9.3.1

Still targeting compatibility with Node 12 and Node 14 (current LTS).