### PR TITLE
feat: support label creation and listing sale batches

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -28,8 +28,17 @@ class Api {
 
   pick (src, ...props) {
     if (!src) return {}
+    let p, d
     return [].concat(props).flat().filter(Boolean).reduce((dest, prop) => {
-      if (typeof src[prop] !== 'undefined') dest[prop] = src[prop]
+      if (typeof prop === 'string') {
+        p = prop
+        d = undefined
+      } else {
+        p = Object.keys(prop)[0]
+        d = prop[p]
+      }
+      if (typeof src[p] !== 'undefined') dest[p] = src[p]
+      else if (typeof d !== 'undefined') dest[p] = d
       return dest
     }, {})
   }

--- a/api/api.js
+++ b/api/api.js
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+const querystring = require('querystring')
+
 class Api {
   constructor (opts) {
     opts = opts || {}
@@ -22,6 +24,20 @@ class Api {
   get client () {
     if (!this._client) this._client = require('../client').get()
     return this._client
+  }
+
+  pick (src, ...props) {
+    if (!src) return {}
+    return [].concat(props).flat().filter(Boolean).reduce((dest, prop) => {
+      if (typeof src[prop] !== 'undefined') dest[prop] = src[prop]
+      return dest
+    }, {})
+  }
+
+  qs (obj, ...props) {
+    if (props.length) obj = this.pick(obj, ...props)
+    const query = querystring.stringify(obj)
+    return query ? '?' + query : ''
   }
 }
 

--- a/api/labels.js
+++ b/api/labels.js
@@ -38,7 +38,7 @@ class LabelsApi extends Api {
     opts = opts || {}
     const orgId = opts.orgId || await this.getOrgId()
     const request = this.pick(label, 'type', 'name', 'description', 'color', 'icon')
-    const r = await this.post(`/orgs/${orgId}/labels`, request, opts)
+    const r = await this.client.post(`/orgs/${orgId}/labels`, request, opts)
     return r && r.body
   }
 }

--- a/api/labels.js
+++ b/api/labels.js
@@ -38,7 +38,7 @@ class LabelsApi extends Api {
 
   async createLabel (label, opts) {
     opts = opts || {}
-    const orgId = opts.orgId || await this.getOrgId()
+    const orgId = opts.orgId || await this.client.getOrgId()
     const request = this.pick(label, 'type', 'name', 'description', 'color', 'icon')
     const r = await this.client.post(`/orgs/${orgId}/labels`, request, opts)
     return r && r.body

--- a/api/labels.js
+++ b/api/labels.js
@@ -21,16 +21,18 @@ class LabelsApi extends Api {
   }
 
   async getLabels (opts = {}) {
-    const {
-      page = 1,
-      size = 50,
-      type = 'sale'
-    } = opts
-
     const orgId = opts.orgId || await this.client.getOrgId()
-    const route = `/orgs/${orgId}/labels?page=${page}&size=${size}&type=${type}`
-    // TODO all other query params
-    const r = await this.client.get(route, opts) // TODO wrap this.client.get that throws on 4xx/5xx response
+    const route = `/orgs/${orgId}/labels` + this.qs(
+      opts,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      { type: 'sale' }, // string or array
+      'reportId', // string
+      'includeDeleted', // boolean
+      'name' // string or array
+    )
+    const r = await this.client.get(route, opts)
     return r && r.body
   }
 

--- a/api/labels.js
+++ b/api/labels.js
@@ -33,6 +33,14 @@ class LabelsApi extends Api {
     const r = await this.client.get(route, opts) // TODO wrap this.client.get that throws on 4xx/5xx response
     return r && r.body
   }
+
+  async createLabel (label, opts) {
+    opts = opts || {}
+    const orgId = opts.orgId || await this.getOrgId()
+    const request = this.pick(label, 'type', 'name', 'description', 'color', 'icon')
+    const r = await this.post(`/orgs/${orgId}/labels`, request, opts)
+    return r && r.body
+  }
 }
 
 module.exports = LabelsApi

--- a/api/products.js
+++ b/api/products.js
@@ -21,15 +21,17 @@ class ProductsApi extends Api {
   }
 
   async getProducts (opts = {}) {
-    const {
-      page = 1,
-      size = 50
-    } = opts
-
-    // TODO params: name (1+ strings), inAnyPcat (boolean)
-
     const orgId = opts.orgId || await this.client.getOrgId()
-    const route = `/orgs/${orgId}/products?page=${page}&size=${size}`
+    const route = `/orgs/${orgId}/products` + this.qs(
+      opts,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      'id',
+      'name',
+      'inAnyPcat', // boolean
+      'withExternalKeys' // boolean
+    )
     const r = await this.client.get(route, opts)
     return r && r.body
   }

--- a/api/reps.js
+++ b/api/reps.js
@@ -21,14 +21,18 @@ class RepsApi extends Api {
   }
 
   async getSearchableReps (opts = {}) {
-    const {
-      page = 1,
-      size = 50
-    } = opts
-
     const orgId = opts.orgId || await this.client.getOrgId()
-    const route = `/orgs/${orgId}/searchable-reps?page=${page}&size=${size}`
-    // TODO all other query params
+    const route = `/orgs/${orgId}/searchable-reps` + this.qs(
+      opts,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      'search',
+      'searchField',
+      'withPlans', // boolean
+      'withExternalKeys', // boolean
+      'includeTeamAncestry' // boolean
+    )
     const r = await this.client.get(route, opts) // TODO wrap this.client.get that throws on 4xx/5xx response
     return r && r.body
   }

--- a/api/sales.js
+++ b/api/sales.js
@@ -37,7 +37,7 @@ class SalesApi extends Api {
 
   async listSaleBatches (opts) {
     opts = opts || {}
-    const orgId = opts.orgId || await this.getOrgId()
+    const orgId = opts.orgId || await this.client.getOrgId()
     const url = `/orgs/${orgId}/sale-batches` + this.qs(opts, 'page', 'size', 'deleted', 'name')
     const r = await this.client.get(url, opts)
     return r && r.body

--- a/api/sales.js
+++ b/api/sales.js
@@ -39,7 +39,7 @@ class SalesApi extends Api {
     opts = opts || {}
     const orgId = opts.orgId || await this.getOrgId()
     const url = `/orgs/${orgId}/sale-batches` + this.qs(opts, 'page', 'size', 'deleted', 'name')
-    const r = await this.client.get(url)
+    const r = await this.client.get(url, opts)
     return r && r.body
   }
 

--- a/api/sales.js
+++ b/api/sales.js
@@ -43,6 +43,7 @@ class SalesApi extends Api {
     return r && r.body
   }
 
+  // deprecated, use createExternalBatch or createFileBatch instead
   async createBatch (opts) {
     const {
       name,
@@ -61,6 +62,24 @@ class SalesApi extends Api {
 
     const route = `/orgs/${orgId}/sale-external-batches`
     const r = await this.client.post(route, request, opts) // TODO wrap this.client.post that throws on 4xx/5xx response
+    return r && r.body
+  }
+
+  async createExternalBatch (batch, opts) {
+    opts = opts || {}
+    const orgId = opts.orgId || await this.client.getOrgId()
+    // externalOrg required
+    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'sales', 'externalOrg')
+    const r = await this.client.post(`/orgs/${orgId}/sale-external-batches`, request, opts)
+    return r && r.body
+  }
+
+  async createFileBatch (batch, opts) {
+    opts = opts || {}
+    const orgId = opts.orgId || await this.client.getOrgId()
+    // rawName required
+    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'sales')
+    const r = await this.client.post(`/orgs/${orgId}/sale-file-batches`, request, opts)
     return r && r.body
   }
 

--- a/api/sales.js
+++ b/api/sales.js
@@ -39,7 +39,7 @@ class SalesApi extends Api {
     opts = opts || {}
     const orgId = opts.orgId || await this.getOrgId()
     const url = `/orgs/${orgId}/sale-batches` + this.qs(opts, 'page', 'size', 'deleted', 'name')
-    const r = await this.get(url)
+    const r = await this.client.get(url)
     return r && r.body
   }
 

--- a/api/sales.js
+++ b/api/sales.js
@@ -35,6 +35,14 @@ class SalesApi extends Api {
     return r && r.body
   }
 
+  async listSaleBatches (opts) {
+    opts = opts || {}
+    const orgId = opts.orgId || await this.getOrgId()
+    const url = `/orgs/${orgId}/sale-batches` + this.qs(opts, 'page', 'size', 'deleted', 'name')
+    const r = await this.get(url)
+    return r && r.body
+  }
+
   async createBatch (opts) {
     const {
       name,


### PR DESCRIPTION
Adds the following:

1. Ability to list sale batches via `GET /orgs/${orgId}/sale-batches`
2. Ability to create labels via `POST /orgs/${orgId}/labels`
3. Support new query params for `GET /orgs/${orgId}/products`
4. Support new query params for `GET /orgs/${orgId}/searchable-reps`
5. Easier way to limit props for a request object via `Api#pick(src, ...props)`
6. Easier way to limit query params (potentially with default value) via `Api#qs(obj, ...props)`
7. Better query string building via `querystring`