### PR TITLE
feat: add modules triggerEvents, customerCategories, and customFields

### DIFF
--- a/api/custom-fields.js
+++ b/api/custom-fields.js
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 SalesVista, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const Api = require('./api')
+
+class CustomFieldsApi extends Api {
+  static get (opts) {
+    return new CustomFieldsApi(opts)
+  }
+
+  async listCustomFields (params, opts) {
+    params = params || {}
+    opts = opts || {}
+    const orgId = params.orgId || opts.orgId || await this.client.getOrgId()
+    const route = `/orgs/${orgId}/custom-fields` + this.qs(
+      params,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      'displayName', // string
+      'withoutArchived', // boolean
+      'withOptions' // boolean
+    )
+    const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+
+  async listOptionsForCustomField (customFieldId, params, opts) {
+    params = params || {}
+    opts = opts || {}
+    const route = `/custom-fields/${customFieldId}/options` + this.qs(
+      params,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      'name', // string
+      'id' // string or array
+    )
+    const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+
+  async createOption (customFieldId, option, opts) {
+    opts = opts || {}
+    // name is required
+    const request = this.pick(option, 'name')
+    const r = await this.client.post(`/custom-fields/${customFieldId}/options`, request, opts)
+    return r && r.body
+  }
+}
+
+module.exports = CustomFieldsApi

--- a/api/customer-categories.js
+++ b/api/customer-categories.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 SalesVista, LLC
+Copyright 2022 SalesVista, LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,47 +15,36 @@ limitations under the License.
 */
 const Api = require('./api')
 
-class ProductsApi extends Api {
+class CustomerCategoriesApi extends Api {
   static get (opts) {
-    return new ProductsApi(opts)
+    return new CustomerCategoriesApi(opts)
   }
 
-  /**
-   * @deprecated Use listProducts instead
-   */
-  async getProducts (opts = {}) {
-    const orgId = opts.orgId || await this.client.getOrgId()
-    const route = `/orgs/${orgId}/products` + this.qs(
-      opts,
-      { page: 1 },
-      { size: 50 },
-      'sort',
-      'id',
-      'name',
-      'inAnyPcat', // boolean
-      'withExternalKeys' // boolean
-    )
-    const r = await this.client.get(route, opts)
-    return r && r.body
-  }
-
-  async listProducts (params, opts) {
+  async listCustomerCategories (params, opts) {
     params = params || {}
     opts = opts || {}
     const orgId = params.orgId || opts.orgId || await this.client.getOrgId()
-    const route = `/orgs/${orgId}/products` + this.qs(
+    const route = `/orgs/${orgId}/customer-categories` + this.qs(
       params,
       { page: 1 },
       { size: 50 },
       'sort',
-      'id',
-      'name',
-      'inAnyPcat', // boolean
-      'withExternalKeys' // boolean
+      'search', // string
+      'searchField', // string or array
+      'withCounts' // boolean
     )
     const r = await this.client.get(route, opts)
     return r && r.body
   }
+
+  async createCustomerCategory (ccat, opts) {
+    opts = opts || {}
+    const orgId = ccat.orgId || opts.orgId || await this.client.getOrgId()
+    // name is required
+    const request = this.pick(ccat, 'name', 'description', 'parent')
+    const r = await this.client.post(`/orgs/${orgId}/customer-categories`, request, opts)
+    return r && r.body
+  }
 }
 
-module.exports = ProductsApi
+module.exports = CustomerCategoriesApi

--- a/api/customers.js
+++ b/api/customers.js
@@ -20,6 +20,9 @@ class CustomersApi extends Api {
     return new CustomersApi(opts)
   }
 
+  /**
+   * @deprecated Use listCustomers instead
+   */
   async getCustomers (opts = {}) {
     const orgId = opts.orgId || await this.client.getOrgId()
     const route = `/orgs/${orgId}/customers` + this.qs(
@@ -33,6 +36,42 @@ class CustomersApi extends Api {
       'withExternalKeys' // boolean
     )
     const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+
+  async listCustomers (params, opts) {
+    params = params || {}
+    opts = opts || {}
+    const orgId = params.orgId || opts.orgId || await this.client.getOrgId()
+    const route = `/orgs/${orgId}/customers` + this.qs(
+      params,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      'id', // string or array
+      'name', // string or array
+      'inAnyCcat', // boolean
+      'withExternalKeys' // boolean
+    )
+    const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+
+  async createCustomer (customer, opts) {
+    opts = opts || {}
+    const orgId = customer.orgId || opts.orgId || await this.client.getOrgId()
+    // name (Name) and slug (Customer Code) required
+    const request = this.pick(customer, 'name', 'slug', 'customerCategory', 'description', 'externalOrg', 'externalKey')
+    const r = await this.client.post(`/orgs/${orgId}/customers`, request, opts)
+    return r && r.body
+  }
+
+  async createExternalBatch (batch, opts) {
+    opts = opts || {}
+    const orgId = batch.orgId || opts.orgId || await this.client.getOrgId()
+    // externalOrg required
+    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'customers', 'externalOrg')
+    const r = await this.client.post(`/orgs/${orgId}/customer-external-batches`, request, opts)
     return r && r.body
   }
 }

--- a/api/labels.js
+++ b/api/labels.js
@@ -36,6 +36,24 @@ class LabelsApi extends Api {
     return r && r.body
   }
 
+  async listLabels (params, opts) {
+    params = params || {}
+    opts = opts || {}
+    const orgId = params.orgId || opts.orgId || await this.client.getOrgId()
+    const route = `/orgs/${orgId}/labels` + this.qs(
+      params,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      { type: 'sale' }, // string or array
+      'reportId', // string
+      'includeDeleted', // boolean
+      'name' // string or array
+    )
+    const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+
   async createLabel (label, opts) {
     opts = opts || {}
     const orgId = opts.orgId || await this.client.getOrgId()

--- a/api/product-categories.js
+++ b/api/product-categories.js
@@ -20,6 +20,9 @@ class ProductCategoriesApi extends Api {
     return new ProductCategoriesApi(opts)
   }
 
+  /**
+   * @deprecated Use listProductCategories instead
+   */
   async getProductCategories (opts = {}) {
     const {
       page = 1,
@@ -28,7 +31,24 @@ class ProductCategoriesApi extends Api {
 
     const orgId = opts.orgId || await this.client.getOrgId()
     const route = `/orgs/${orgId}/product-categories?page=${page}&size=${size}`
-    const r = await this.client.get(route, opts) // TODO wrap this.client.get that throws on 4xx/5xx response
+    const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+
+  async listProductCategories (params, opts) {
+    params = params || {}
+    opts = opts || {}
+    const orgId = params.orgId || opts.orgId || await this.client.getOrgId()
+    const route = `/orgs/${orgId}/product-categories` + this.qs(
+      params,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      'search', // string
+      'searchField', // string or array
+      'withCounts' // boolean
+    )
+    const r = await this.client.get(route, opts)
     return r && r.body
   }
 }

--- a/api/reps.js
+++ b/api/reps.js
@@ -20,6 +20,9 @@ class RepsApi extends Api {
     return new RepsApi(opts)
   }
 
+  /**
+   * @deprecated Use listSearchableReps instead
+   */
   async getSearchableReps (opts = {}) {
     const orgId = opts.orgId || await this.client.getOrgId()
     const route = `/orgs/${orgId}/searchable-reps` + this.qs(
@@ -33,7 +36,26 @@ class RepsApi extends Api {
       'withExternalKeys', // boolean
       'includeTeamAncestry' // boolean
     )
-    const r = await this.client.get(route, opts) // TODO wrap this.client.get that throws on 4xx/5xx response
+    const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+
+  async listSearchableReps (params, opts) {
+    params = params || {}
+    opts = opts || {}
+    const orgId = params.orgId || opts.orgId || await this.client.getOrgId()
+    const route = `/orgs/${orgId}/searchable-reps` + this.qs(
+      params,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      'search',
+      'searchField',
+      'withPlans', // boolean
+      'withExternalKeys', // boolean
+      'includeTeamAncestry' // boolean
+    )
+    const r = await this.client.get(route, opts)
     return r && r.body
   }
 }

--- a/api/sales.js
+++ b/api/sales.js
@@ -20,6 +20,9 @@ class SalesApi extends Api {
     return new SalesApi(opts)
   }
 
+  /**
+   * @deprecated Use listSales instead
+   */
   async getSales (opts = {}) {
     const {
       page = 1,
@@ -31,10 +34,51 @@ class SalesApi extends Api {
     let route = `/orgs/${orgId}/sales?page=${page}&size=${size}`
     if (externalKey) route += `&externalKeyLike=${externalKey}`
 
-    const r = await this.client.get(route, opts) // TODO wrap this.client.get that throws on 4xx/5xx response
+    const r = await this.client.get(route, opts)
     return r && r.body
   }
 
+  async listSales (params, opts) {
+    params = params || {}
+    opts = opts || {}
+    const orgId = params.orgId || opts.orgId || await this.client.getOrgId()
+    const route = `/orgs/${orgId}/sales` + this.qs(
+      params,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      'teamId', // string or array
+      'includeChildTeams', // boolean
+      'productCategoryId', // string or array
+      'customerCategoryId', // string or array
+      'labelId', // string or array
+      'repId', // string or array
+      'id', // string or array
+      'productId', // string or array
+      'customerId', // string or array
+      'effectiveDate', // string or array
+      'effectiveDateAfter', // string like '2022-02-12'
+      'effectiveDateBefore', // string
+      'transactionDate', // string or array
+      'transactionDateAfter', // string
+      'transactionDateBefore', // string
+      'reportId', // string or array
+      'batchId', // string or array
+      'referenceId', // string
+      'noteLike', // string (multiple values requires multiple params)
+      'source', // string or array
+      'externalKeyLike', // string or array
+      'withWarnings', // boolean
+      'status', // string or array
+      'type' // string or array
+    )
+    const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+
+  /**
+   * @deprecated Use listSaleBatches2 instead
+   */
   async listSaleBatches (opts) {
     opts = opts || {}
     const orgId = opts.orgId || await this.client.getOrgId()
@@ -43,7 +87,18 @@ class SalesApi extends Api {
     return r && r.body
   }
 
-  // deprecated, use createExternalBatch or createFileBatch instead
+  async listSaleBatches2 (params, opts) {
+    params = params || {}
+    opts = opts || {}
+    const orgId = params.orgId || opts.orgId || await this.client.getOrgId()
+    const url = `/orgs/${orgId}/sale-batches` + this.qs(params, 'page', 'size', 'deleted', 'name')
+    const r = await this.client.get(url, opts)
+    return r && r.body
+  }
+
+  /**
+   * @deprecated Use createExternalBatch or createFileBatch instead
+   */
   async createBatch (opts) {
     const {
       name,
@@ -61,7 +116,7 @@ class SalesApi extends Api {
     if (sales) request.sales = sales
 
     const route = `/orgs/${orgId}/sale-external-batches`
-    const r = await this.client.post(route, request, opts) // TODO wrap this.client.post that throws on 4xx/5xx response
+    const r = await this.client.post(route, request, opts)
     return r && r.body
   }
 
@@ -97,7 +152,7 @@ class SalesApi extends Api {
     if (sales) request.sales = sales
 
     const route = `/sale-batches/${batchId}`
-    const r = await this.client.put(route, request, opts) // TODO wrap this.client.put that throws on 4xx/5xx response
+    const r = await this.client.put(route, request, opts)
     return r && r.body
   }
 }

--- a/api/trigger-events.js
+++ b/api/trigger-events.js
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 SalesVista, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const Api = require('./api')
+
+class TriggerEventsApi extends Api {
+  static get (opts) {
+    return new TriggerEventsApi(opts)
+  }
+
+  // types
+  async listTriggerEventTypes (params, opts) {
+    params = params || {}
+    opts = opts || {}
+    const orgId = params.orgId || opts.orgId || await this.client.getOrgId()
+    const route = `/orgs/${orgId}/trigger-event-types` + this.qs(
+      params,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      'reportId', // string
+      'includeDeleted', // boolean (mutually exclusive with reportId)
+      'entityType', // string or array
+      'name' // string // TODO URLSearchParams#append() for any values that contain comma
+    )
+    const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+
+  async getTriggerEventType (eventTypeId, opts) {
+    const r = await this.client.get(`/trigger-event-types/${eventTypeId}`, opts)
+    return r && r.body
+  }
+
+  async createTriggerEventType (eventType, opts) {
+    opts = opts || {}
+    const orgId = eventType.orgId || opts.orgId || await this.client.getOrgId()
+    const request = this.pick(eventType, { entityType: 'sale' }, 'name', 'description')
+    const r = await this.client.post(`/orgs/${orgId}/trigger-event-types`, request, opts)
+    return r && r.body
+  }
+
+  async updateTriggerEventType (eventType, opts) {
+    const request = this.pick(eventType, 'version', 'name', 'entityType', 'description')
+    const r = await this.client.put(`/trigger-event-types/${eventType?.id}`, request, opts)
+    return r && r.body
+  }
+
+  // events
+  async listTriggerEvents (params, opts) {
+    params = params || {}
+    opts = opts || {}
+    const orgId = params.orgId || opts.orgId || await this.client.getOrgId()
+    const route = `/orgs/${orgId}/trigger-events` + this.qs(
+      params,
+      { page: 1 },
+      { size: 50 },
+      'sort',
+      'entityType', // string or array
+      'entityId', // string or array
+      'triggerEventTypeId' // string or array
+    )
+    const r = await this.client.get(route, opts)
+    return r && r.body
+  }
+
+  async getTriggerEvent (eventId, opts) {
+    const r = await this.client.get(`/trigger-events/${eventId}`, opts)
+    return r && r.body
+  }
+
+  async createTriggerEvent (event, opts) {
+    opts = opts || {}
+    const orgId = event.orgId || opts.orgId || await this.client.getOrgId()
+    const request = this.pick(event, 'entityId', { entityType: 'sale' }, 'triggerEventType', 'effectiveDate')
+    const r = await this.client.post(`/orgs/${orgId}/trigger-events`, request, opts)
+    return r && r.body
+  }
+}
+
+module.exports = TriggerEventsApi

--- a/client.js
+++ b/client.js
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-const { SVError } = require('./errors')
+const { SVError, SVApiError } = require('./errors')
 
 class SVClient {
   static get defaultBaseUrl () {
@@ -205,9 +205,11 @@ class SVClient {
           try {
             response = await got(url, gotOpts)
           } catch (err2) {
-            if (err2.response) response = err2.response
+            throw new SVApiError(url, err2)
           }
         }
+      } else {
+        throw new SVApiError(url, err)
       }
     }
     return response

--- a/client.js
+++ b/client.js
@@ -68,13 +68,16 @@ class SVClient {
     this._cacheStrategy = opts.cacheStrategy || this._cacheStrategy
 
     // api modules
+    this._customerCategories = opts.customerCategories || this._customerCategories
     this._customers = opts.customers || this._customers
+    this._customFields = opts.customFields || this._customFields
     this._labels = opts.labels || this._labels
     this._org = opts.org || this._org
     this._productCategories = opts.productCategories || this._productCategories
     this._products = opts.products || this._products
     this._reps = opts.reps || this._reps
     this._sales = opts.sales || this._sales
+    this._triggerEvents = opts.triggerEvents || this._triggerEvents
 
     return this
   }
@@ -261,9 +264,19 @@ class SVClient {
     return this.orgId
   }
 
+  get customerCategories () {
+    if (!this._customerCategories) this._customerCategories = require('./api/customer-categories').get({ client: this })
+    return this._customerCategories
+  }
+
   get customers () {
     if (!this._customers) this._customers = require('./api/customers').get({ client: this })
     return this._customers
+  }
+
+  get customFields () {
+    if (!this._customFields) this._customFields = require('./api/custom-fields').get({ client: this })
+    return this._customFields
   }
 
   get labels () {
@@ -294,6 +307,11 @@ class SVClient {
   get sales () {
     if (!this._sales) this._sales = require('./api/sales').get({ client: this })
     return this._sales
+  }
+
+  get triggerEvents () {
+    if (!this._triggerEvents) this._triggerEvents = require('./api/trigger-events').get({ client: this })
+    return this._triggerEvents
   }
 
   // this method will throw an error for any of the following 4 scenarios:

--- a/errors.js
+++ b/errors.js
@@ -25,6 +25,37 @@ class SVError extends Error {
   }
 }
 
+class SVApiError extends SVError {
+  constructor (url, gotErr) {
+    const method = gotErr?.options?.method || 'HTTP'
+    const statusCode = gotErr?.response?.statusCode || 555
+    super(`${statusCode} response from ${method} ${url}`)
+    this.method = method
+    this.url = url
+    this.statusCode = statusCode
+    this.body = gotErr?.response?.body
+    this.headers = gotErr?.response?.headers
+    if (gotErr) this.withCause(gotErr)
+  }
+
+  toObject () {
+    return {
+      method: this.method,
+      url: this.url,
+      statusCode: this.statusCode,
+      headers: this.headers,
+      body: this.body,
+      message: this.message,
+      stack: this.stack
+    }
+  }
+
+  toJSON () {
+    return this.toObject()
+  }
+}
+
 module.exports = {
-  SVError
+  SVError,
+  SVApiError
 }


### PR DESCRIPTION
To support the following endpoints:

- Trigger Event Types
  - GET /orgs/:id/trigger-event-types
  - POST /orgs/:id/trigger-event-types
  - GET /trigger-event-types/:id
  - PUT /trigger-event-types/:id
- Trigger Events
  - GET /orgs/:id/trigger-events
  - POST /orgs/:id/trigger-events
  - GET /trigger-events/:id
- Customers
  - POST /orgs/:id/customers
  - POST /orgs/:id/customer-external-batches
- Customer Categories
  - GET /orgs/:id/customer-categories
  - POST /orgs/:id/customer-categories
- Custom Fields
  - GET /orgs/:id/custom-fields
  - GET /custom-fields/:id/options
  - POST /custom-fields/:id/options

**BREAKING CHANGE**: Also changed error response handling to throw a custom `SVApiError` error instead of returning the response body.