### PR TITLE
feat: add createProduct and createExternalBatch to products api module

### DIFF
--- a/api/products.js
+++ b/api/products.js
@@ -56,6 +56,24 @@ class ProductsApi extends Api {
     const r = await this.client.get(route, opts)
     return r && r.body
   }
+
+  async createProduct (product, opts) {
+    opts = opts || {}
+    const orgId = product.orgId || opts.orgId || await this.client.getOrgId()
+    // productCode and displayName required
+    const request = this.pick(product, 'productCode', 'displayName', 'description', 'productCategory', 'externalOrg', 'externalKey')
+    const r = await this.client.post(`/orgs/${orgId}/products`, request, opts)
+    return r && r.body
+  }
+
+  async createExternalBatch (batch, opts) {
+    opts = opts || {}
+    const orgId = batch.orgId || opts.orgId || await this.client.getOrgId()
+    // externalOrg required
+    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'products', 'externalOrg')
+    const r = await this.client.post(`/orgs/${orgId}/product-external-batches`, request, opts)
+    return r && r.body
+  }
 }
 
 module.exports = ProductsApi

--- a/api/trigger-events.js
+++ b/api/trigger-events.js
@@ -84,7 +84,7 @@ class TriggerEventsApi extends Api {
   async createTriggerEvent (event, opts) {
     opts = opts || {}
     const orgId = event.orgId || opts.orgId || await this.client.getOrgId()
-    const request = this.pick(event, 'entityId', { entityType: 'sale' }, 'triggerEventType', 'effectiveDate')
+    const request = this.pick(event, 'entityId', { entityType: 'sale' }, 'triggerEventType', 'effectiveDate', 'percentage')
     const r = await this.client.post(`/orgs/${orgId}/trigger-events`, request, opts)
     return r && r.body
   }


### PR DESCRIPTION
Adds the following:

1. Ability to create an individual product via `POST /orgs/${orgId}/products`
2. Ability to create an "external" batch of products (multiple products from an external source) via `POST /orgs/${orgId}/product-external-batches`

Needed for upcoming integration functionality.