### PR TITLE
feat: support externalKey param for sales.listSales

### DIFF
--- a/api/sales.js
+++ b/api/sales.js
@@ -67,6 +67,7 @@ class SalesApi extends Api {
       'referenceId', // string
       'noteLike', // string (multiple values requires multiple params)
       'source', // string or array
+      'externalKey', // string or array
       'externalKeyLike', // string or array
       'withWarnings', // boolean
       'status', // string or array


### PR DESCRIPTION
Now that the api supports an exact match for external key instead of just an approximate match.