### PR TITLE
chore: replace Node 14 with Node 18 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 18
           - 16
-          - 14
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
Also bump version of `actions/checkout` and `actions/setup-node`