### PR TITLE
feat: add ability to create product categories

### DIFF
--- a/api/product-categories.js
+++ b/api/product-categories.js
@@ -56,7 +56,7 @@ class ProductCategoriesApi extends Api {
     opts = opts || {}
     const orgId = pcat.orgId || opts.orgId || await this.client.getOrgId()
     // name is required
-    const request = this.pick(pcat, 'name', 'description', 'parent')
+    const request = this.pick(pcat, 'name', 'parent')
     const r = await this.client.post(`/orgs/${orgId}/product-categories`, request, opts)
     return r && r.body
   }

--- a/api/product-categories.js
+++ b/api/product-categories.js
@@ -51,6 +51,15 @@ class ProductCategoriesApi extends Api {
     const r = await this.client.get(route, opts)
     return r && r.body
   }
+
+  async createProductCategory (pcat, opts) {
+    opts = opts || {}
+    const orgId = pcat.orgId || opts.orgId || await this.client.getOrgId()
+    // name is required
+    const request = this.pick(pcat, 'name', 'description', 'parent')
+    const r = await this.client.post(`/orgs/${orgId}/product-categories`, request, opts)
+    return r && r.body
+  }
 }
 
 module.exports = ProductCategoriesApi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesvista/client",
-  "version": "0.10.0",
+  "version": "0.9.0",
   "description": "Node.js SDK for the SalesVista REST API",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesvista/client",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Node.js SDK for the SalesVista REST API",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## Description
This PR allows a user to easily create `product-categories`. Its current main objective is to allow us to auto-create `product-categories` that are referenced by other entities (e.g. `sales`).