### PR TITLE
feat: add support for background process events via new bgpEvents module and svExecId

### DIFF
--- a/api/bgp-events.js
+++ b/api/bgp-events.js
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 SalesVista, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const Api = require('./api')
+
+class BgpEventsApi extends Api {
+  static get (opts) {
+    return new BgpEventsApi(opts)
+  }
+
+  async logEventForOrg (event, opts) {
+    opts = opts || {}
+    const orgId = opts.orgId || await this.client.getOrgId()
+    // required: execType, execKey, event, timestamp
+    const request = this.pick(
+      event,
+      'execType', // string, max 64 chars, case-insensitive
+      'execKey', // string, max 128 chars
+      'event', // string, max 64 chars, case-insensitive
+      'timestamp', // number or ISO string
+      'eventKey', // string, max 128 chars
+      'processName', // string, truncated to 64 chars, case-insensitive
+      'execName', // string, truncated to 255 chars
+      'sourceType', // string, truncated to 64 chars, case-insensitive
+      'sourceName', // string, truncated to 255 chars
+      'sourceRecordCount', // integer
+      'percentageComplete', // number 0-100, up to 6 decimals
+      'mainEntityType', // string, truncated to 63 chars, case-insensitive
+      'hidden', // boolean
+      'userMessage', // string
+      'reason', // string or object or array
+      'txnExternalKey', // string, truncated to 255 chars
+      'rowId', // string, truncated to 36 chars
+      'correlation' // string, truncated to 255 chars
+    )
+    const r = await this.client.post(`/orgs/${orgId}/bgp-events`, request, opts)
+    return r && r.body // success (boolean), svExecId (string), svEventId (string)
+  }
+
+  async logEventForExec (svExecId, event, opts) {
+    // required: event, timestamp
+    const request = this.pick(
+      event,
+      'event', // string, max 64 chars, case-insensitive
+      'timestamp', // number or ISO string
+      'eventKey', // string, max 128 chars
+      'processName', // string, truncated to 64 chars, case-insensitive
+      'execName', // string, truncated to 255 chars
+      'sourceType', // string, truncated to 64 chars, case-insensitive
+      'sourceName', // string, truncated to 255 chars
+      'sourceRecordCount', // integer
+      'percentageComplete', // number 0-100, up to 6 decimals
+      'mainEntityType', // string, truncated to 63 chars, case-insensitive
+      'hidden', // boolean
+      'userMessage', // string
+      'reason', // string or object or array
+      'txnExternalKey', // string, truncated to 255 chars
+      'rowId', // string, truncated to 36 chars
+      'correlation' // string, truncated to 255 chars
+    )
+    const r = await this.client.post(`/bgp-execs/${svExecId}/events`, request, opts)
+    return r && r.body // success (boolean), svExecId (echoed string), svEventId (string)
+  }
+
+  async logManyEventsForExec (svExecId, wrapper, opts) {
+    const request = this.pick(
+      wrapper,
+      'event', // string, max 64 chars, case-insensitive
+      'timestamp', // number or ISO string
+      'percentageComplete', // number 0-100, up to 6 decimals
+      'hidden', // boolean
+      'events' // array of event objects, must have unique eventKey or timestamp
+      // events also expects: userMessage, reason, txnExternalKey, rowId, correlation
+    )
+    const r = await this.client.post(`/bgp-execs/${svExecId}/many-events`, request, opts)
+    return r && r.body // success (boolean), numNewEvents (integer)
+  }
+}
+
+module.exports = BgpEventsApi

--- a/api/custom-fields.js
+++ b/api/custom-fields.js
@@ -55,7 +55,7 @@ class CustomFieldsApi extends Api {
   async createOption (customFieldId, option, opts) {
     opts = opts || {}
     // name is required
-    const request = this.pick(option, 'name')
+    const request = this.pick(option, 'name', 'svExecId')
     const r = await this.client.post(`/custom-fields/${customFieldId}/options`, request, opts)
     return r && r.body
   }

--- a/api/customer-categories.js
+++ b/api/customer-categories.js
@@ -41,7 +41,7 @@ class CustomerCategoriesApi extends Api {
     opts = opts || {}
     const orgId = ccat.orgId || opts.orgId || await this.client.getOrgId()
     // name is required
-    const request = this.pick(ccat, 'name', 'description', 'parent')
+    const request = this.pick(ccat, 'name', 'description', 'parent', 'svExecId')
     const r = await this.client.post(`/orgs/${orgId}/customer-categories`, request, opts)
     return r && r.body
   }

--- a/api/customers.js
+++ b/api/customers.js
@@ -61,13 +61,13 @@ class CustomersApi extends Api {
     opts = opts || {}
     const orgId = customer.orgId || opts.orgId || await this.client.getOrgId()
     // name (Name) and slug (Customer Code) required
-    const request = this.pick(customer, 'name', 'slug', 'customerCategory', 'description', 'externalOrg', 'externalKey')
+    const request = this.pick(customer, 'name', 'slug', 'customerCategory', 'description', 'externalOrg', 'externalKey', 'svExecId')
     const r = await this.client.post(`/orgs/${orgId}/customers`, request, opts)
     return r && r.body
   }
 
   async updateCustomer (customer, opts) {
-    const request = this.pick(customer, 'id', 'name', 'slug', 'description', 'version', 'externalOrg', 'externalKey', 'customerCategory')
+    const request = this.pick(customer, 'id', 'name', 'slug', 'description', 'version', 'externalOrg', 'externalKey', 'customerCategory', 'svExecId')
     const r = await this.client.put(`/customers/${request.id}`, request, opts)
     return r && r.body
   }
@@ -76,7 +76,7 @@ class CustomersApi extends Api {
     opts = opts || {}
     const orgId = batch.orgId || opts.orgId || await this.client.getOrgId()
     // externalOrg required
-    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'customers', 'externalOrg')
+    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'customers', 'externalOrg', 'svExecId')
     const r = await this.client.post(`/orgs/${orgId}/customer-external-batches`, request, opts)
     return r && r.body
   }

--- a/api/labels.js
+++ b/api/labels.js
@@ -57,7 +57,7 @@ class LabelsApi extends Api {
   async createLabel (label, opts) {
     opts = opts || {}
     const orgId = opts.orgId || await this.client.getOrgId()
-    const request = this.pick(label, 'type', 'name', 'description', 'color', 'icon')
+    const request = this.pick(label, 'type', 'name', 'description', 'color', 'icon', 'svExecId')
     const r = await this.client.post(`/orgs/${orgId}/labels`, request, opts)
     return r && r.body
   }

--- a/api/product-categories.js
+++ b/api/product-categories.js
@@ -56,7 +56,7 @@ class ProductCategoriesApi extends Api {
     opts = opts || {}
     const orgId = pcat.orgId || opts.orgId || await this.client.getOrgId()
     // name is required
-    const request = this.pick(pcat, 'name', 'parent')
+    const request = this.pick(pcat, 'name', 'parent', 'svExecId')
     const r = await this.client.post(`/orgs/${orgId}/product-categories`, request, opts)
     return r && r.body
   }

--- a/api/products.js
+++ b/api/products.js
@@ -61,13 +61,13 @@ class ProductsApi extends Api {
     opts = opts || {}
     const orgId = product.orgId || opts.orgId || await this.client.getOrgId()
     // productCode and displayName required
-    const request = this.pick(product, 'productCode', 'displayName', 'description', 'productCategory', 'externalOrg', 'externalKey')
+    const request = this.pick(product, 'productCode', 'displayName', 'description', 'productCategory', 'externalOrg', 'externalKey', 'svExecId')
     const r = await this.client.post(`/orgs/${orgId}/products`, request, opts)
     return r && r.body
   }
 
   async updateProduct (product, opts) {
-    const request = this.pick(product, 'id', 'productCode', 'displayName', 'description', 'version', 'externalOrg', 'externalKey', 'productCategory')
+    const request = this.pick(product, 'id', 'productCode', 'displayName', 'description', 'version', 'externalOrg', 'externalKey', 'productCategory', 'svExecId')
     const r = await this.client.put(`/products/${request.id}`, request, opts)
     return r && r.body
   }
@@ -76,7 +76,7 @@ class ProductsApi extends Api {
     opts = opts || {}
     const orgId = batch.orgId || opts.orgId || await this.client.getOrgId()
     // externalOrg required
-    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'products', 'externalOrg')
+    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'products', 'externalOrg', 'svExecId')
     const r = await this.client.post(`/orgs/${orgId}/product-external-batches`, request, opts)
     return r && r.body
   }

--- a/api/sales.js
+++ b/api/sales.js
@@ -161,7 +161,7 @@ class SalesApi extends Api {
     opts = opts || {}
     const orgId = opts.orgId || await this.client.getOrgId()
     // externalOrg required
-    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'sales', 'externalOrg')
+    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'sales', 'externalOrg', 'svExecId')
     const r = await this.client.post(`/orgs/${orgId}/sale-external-batches`, request, opts)
     return r && r.body
   }
@@ -170,23 +170,15 @@ class SalesApi extends Api {
     opts = opts || {}
     const orgId = opts.orgId || await this.client.getOrgId()
     // rawName required
-    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'sales')
+    const request = this.pick(batch, 'name', 'rawName', 'rawNumBytes', 'rawNumRows', 'rawFormat', 'sales', 'svExecId')
     const r = await this.client.post(`/orgs/${orgId}/sale-file-batches`, request, opts)
     return r && r.body
   }
 
   async updateBatch (batchId, version, opts) {
-    const {
-      name,
-      sales // verify it is an array?
-    } = opts
-
-    const request = {
-      version,
-      name
-    }
-
-    if (sales) request.sales = sales
+    opts = opts || {}
+    const request = this.pick(opts, 'name', 'sales', 'svExecId')
+    request.version = version
 
     const route = `/sale-batches/${batchId}`
     const r = await this.client.put(route, request, opts)

--- a/api/trigger-events.js
+++ b/api/trigger-events.js
@@ -47,13 +47,13 @@ class TriggerEventsApi extends Api {
   async createTriggerEventType (eventType, opts) {
     opts = opts || {}
     const orgId = eventType.orgId || opts.orgId || await this.client.getOrgId()
-    const request = this.pick(eventType, { entityType: 'sale' }, 'name', 'description')
+    const request = this.pick(eventType, { entityType: 'sale' }, 'name', 'description', 'svExecId')
     const r = await this.client.post(`/orgs/${orgId}/trigger-event-types`, request, opts)
     return r && r.body
   }
 
   async updateTriggerEventType (eventType, opts) {
-    const request = this.pick(eventType, 'version', 'name', 'entityType', 'description')
+    const request = this.pick(eventType, 'version', 'name', 'entityType', 'description', 'svExecId')
     const r = await this.client.put(`/trigger-event-types/${eventType?.id}`, request, opts)
     return r && r.body
   }
@@ -84,7 +84,7 @@ class TriggerEventsApi extends Api {
   async createTriggerEvent (event, opts) {
     opts = opts || {}
     const orgId = event.orgId || opts.orgId || await this.client.getOrgId()
-    const request = this.pick(event, 'entityId', { entityType: 'sale' }, 'triggerEventType', 'effectiveDate', 'percentage')
+    const request = this.pick(event, 'entityId', { entityType: 'sale' }, 'triggerEventType', 'effectiveDate', 'percentage', 'svExecId')
     const r = await this.client.post(`/orgs/${orgId}/trigger-events`, request, opts)
     return r && r.body
   }

--- a/client.js
+++ b/client.js
@@ -68,6 +68,7 @@ class SVClient {
     this._cacheStrategy = opts.cacheStrategy || this._cacheStrategy
 
     // api modules
+    this._bgpEvents = opts.bgpEvents || this._bgpEvents
     this._customerCategories = opts.customerCategories || this._customerCategories
     this._customers = opts.customers || this._customers
     this._customFields = opts.customFields || this._customFields
@@ -263,6 +264,11 @@ class SVClient {
     const token = await this.getToken(true)
     if (token && token.org_id) this.orgId = token.org_id
     return this.orgId
+  }
+
+  get bgpEvents () {
+    if (!this._bgpEvents) this._bgpEvents = require('./api/bgp-events').get({ client: this })
+    return this._bgpEvents
   }
 
   get customerCategories () {


### PR DESCRIPTION
Adds support for creating background process events.

This consists of the following API endpoints to log events:
1. `client.bgpEvents.logEventForOrg()` ➡️ `POST /orgs/:id/bgp-events` to log the first event of a new execution
2. `client.bgpEvents.logEventForExec()` ➡️ `POST /bgp-execs/:id/events` to log a single subsequent event for an existing execution
3. `client.bgpEvents.logManyEventsForExec()` ➡️ `POST /bgp-execs/:id/many-events` to log several subsequent events at the same time for an existing execution

And allowing an `svExecId` property to be included in DTO requests for all other normal entity create/update endpoints, which allows the API to associate entity actions with a particular background process execution.

The idea for the data flow is this:
1. Log the beginning of a background process execution via `client.bgpEvents.logEventForOrg()` with a "start" event, and receive an `svExecId` in the response.
2. Include the `svExecId` value in subsequent create/update calls during execution.
3. Log the end of the bgp execution via `client.bgpEvents.logEventForExec()`

The result should be transparency into what process/job ran, how long it took, and what its results were (including the entities created/updated/deleted).